### PR TITLE
Task PM-612: Filter markets by collateral token address from config

### DIFF
--- a/src/routes/MarketList/store/actions/fetchMarkets.js
+++ b/src/routes/MarketList/store/actions/fetchMarkets.js
@@ -7,7 +7,7 @@ import { BoundsRecord, CategoricalMarketRecord, ScalarMarketRecord, OutcomeRecor
 import addMarkets from './addMarkets'
 
 const config = getConfiguration()
-const { address: collateralTokenConfigAddress } = getCollateralToken()
+const { address: collateralTokenConfigAddress } = getCollateralToken() || {}
 const whitelisted = config.whitelist || {}
 
 const addresses = Object.keys(whitelisted).map(hexWithoutPrefix)

--- a/src/routes/MarketList/store/actions/fetchMarkets.js
+++ b/src/routes/MarketList/store/actions/fetchMarkets.js
@@ -159,5 +159,5 @@ export const processMarketResponse = (dispatch, response) => {
 }
 
 export default () => dispatch =>
-  requestFromRestAPI('markets', { creator: addresses.join() }).then(response =>
-    processMarketResponse(dispatch, response))
+  requestFromRestAPI('markets', { creator: addresses.join() })
+    .then(response => processMarketResponse(dispatch, response))

--- a/src/routes/MarketList/store/actions/fetchMarkets.js
+++ b/src/routes/MarketList/store/actions/fetchMarkets.js
@@ -1,12 +1,13 @@
 import { List } from 'immutable'
 import { requestFromRestAPI } from 'api/utils/fetch'
 import { hexWithoutPrefix } from 'utils/helpers'
-import { getConfiguration } from 'utils/features'
+import { getConfiguration, getCollateralToken } from 'utils/features'
 import { OUTCOME_TYPES } from 'utils/constants'
 import { BoundsRecord, CategoricalMarketRecord, ScalarMarketRecord, OutcomeRecord } from 'store/models'
 import addMarkets from './addMarkets'
 
 const config = getConfiguration()
+const { address: collateralTokenConfigAddress } = getCollateralToken()
 const whitelisted = config.whitelist || {}
 
 const addresses = Object.keys(whitelisted).map(hexWithoutPrefix)
@@ -16,27 +17,28 @@ const buildOutcomesFrom = (outcomes, outcomeTokensSold, marginalPrices) => {
     return List([])
   }
 
-  const outcomesRecords = outcomes.map((outcome, index) => new OutcomeRecord({
-    name: outcome,
-    marginalPrice: marginalPrices[index],
-    outcomeTokensSold: outcomeTokensSold[index],
-  }))
+  const outcomesRecords = outcomes.map((outcome, index) =>
+    new OutcomeRecord({
+      name: outcome,
+      marginalPrice: marginalPrices[index],
+      outcomeTokensSold: outcomeTokensSold[index],
+    }))
 
   return List(outcomesRecords)
 }
 
-const buildBoundsFrom = (lower, upper, unit, decimals) => BoundsRecord({
-  lower, upper, unit, decimals: parseInt(decimals, 10),
-})
+const buildBoundsFrom = (lower, upper, unit, decimals) =>
+  BoundsRecord({
+    lower,
+    upper,
+    unit,
+    decimals: parseInt(decimals, 10),
+  })
 
 const buildScalarMarket = (market) => {
   const {
     stage,
-    contract: {
-      address,
-      creationDate,
-      creator,
-    },
+    contract: { address, creationDate, creator },
     tradingVolume,
     funding,
     netOutcomeTokensSold,
@@ -49,11 +51,7 @@ const buildScalarMarket = (market) => {
         isOutcomeSet,
         outcome,
         eventDescription: {
-          title,
-          description,
-          resolutionDate,
-          unit,
-          decimals,
+          title, description, resolutionDate, unit, decimals,
         },
       },
     },
@@ -99,10 +97,7 @@ const buildCategoricalMarket = (market) => {
         isOutcomeSet,
         outcome: winningOutcomeIndex,
         eventDescription: {
-          title,
-          description,
-          resolutionDate,
-          outcomes: outcomeLabels,
+          title, description, resolutionDate, outcomes: outcomeLabels,
         },
       },
     },
@@ -135,18 +130,18 @@ const builderFunctions = {
   [OUTCOME_TYPES.SCALAR]: buildScalarMarket,
 }
 
-export const extractMarkets = markets => markets.map((market) => {
-  const marketType = market.event.type
+export const extractMarkets = markets =>
+  markets.map((market) => {
+    const marketType = market.event.type
 
-  const builder = builderFunctions[marketType]
+    const builder = builderFunctions[marketType]
 
-  if (!builder) {
-    throw new Error(`No builder function associated with type '${marketType}'`)
-  }
+    if (!builder) {
+      throw new Error(`No builder function associated with type '${marketType}'`)
+    }
 
-  return builder.call(builder, market)
-})
-
+    return builder.call(builder, market)
+  })
 
 export const processMarketResponse = (dispatch, response) => {
   if (!response || !response.results) {
@@ -154,10 +149,15 @@ export const processMarketResponse = (dispatch, response) => {
     return
   }
 
-  const marketRecords = extractMarkets(response.results)
+  let marketRecords = extractMarkets(response.results)
+
+  if (collateralTokenConfigAddress) {
+    marketRecords = marketRecords.filter(({ collateralToken }) => collateralToken === hexWithoutPrefix(collateralTokenConfigAddress))
+  }
+
   dispatch(addMarkets(marketRecords))
 }
 
 export default () => dispatch =>
-  requestFromRestAPI('markets', { creator: addresses.join() })
-    .then(response => processMarketResponse(dispatch, response))
+  requestFromRestAPI('markets', { creator: addresses.join() }).then(response =>
+    processMarketResponse(dispatch, response))


### PR DESCRIPTION
### Description
* Add filter to `processMarketResponse` if a collateral token specified in config

### Which Steps did I take to verify my PR?
* Tested multiple collateral token in config and made sure everything is working

### Background Information
* I wasn't really sure if the right place to do it is selectors (previously filters were done there) or response processing, I chose response processing because I feel like we don't want to save unfiltered markets at all. Feel free to change if you disagree :)