### PR TITLE
Bug PM-606: Fix overlap, fix expandable show condition, fix return sign

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -98,9 +98,11 @@ class Header extends Component {
     } = this.props
 
     let walletConnected = hasWallet
-    if (tournamentEnabled && useMetamask) {
-      walletConnected = hasWallet && mainnetAddress
+
+    if (tournamentEnabled && useMetamask && requireRegistration) {
+      walletConnected = hasWallet && !!mainnetAddress
     }
+
 
     const logoVars = {}
     if (tournamentEnabled) {

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/ScalarSlider/scalarSlider.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/ScalarSlider/scalarSlider.mod.scss
@@ -129,9 +129,9 @@ $scalarSliderBackground: #d6d8d8;
   }
 
   .lowerBound, .upperBound {
-    width: 20%;
+    width: 44%;
     min-width: 120px;
-    padding: 0 12px;
+    padding: 0 18px;
 
     .boundLabel {
       text-transform: uppercase;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
@@ -128,7 +128,7 @@ class MarketBuySharesForm extends Component {
         </span>
       )
 
-      const returnSign = maximumWin > 0 ? '' : '+'
+      const returnSign = maximumWin > 0 ? '+' : ''
       maxReturnField = (
         <span className={cx('marketBuyWin', 'winInfoRow', 'max')}>
           {returnSign}

--- a/src/routes/MarketDetails/components/ExpandableViews/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/index.js
@@ -13,10 +13,15 @@ const showExpandableTournament = (props) => {
   if (!isFeatureEnabled('tournament')) {
     return true
   }
+  const requireRegistration = isFeatureEnabled('registration')
 
   const providerConfig = getProviderConfig()
   let showExpandable = false
-  if (providerConfig.default === WALLET_PROVIDER.METAMASK && !!props.defaultAccount && !!props.mainnetAddress) {
+  if (
+    providerConfig.default === WALLET_PROVIDER.METAMASK &&
+    !!props.defaultAccount &&
+    (requireRegistration ? !!props.mainnetAddress : true)
+  ) {
     showExpandable = true
   } else if (providerConfig === WALLET_PROVIDER.UPORT && !!props.defaultAccount) {
     showExpandable = true


### PR DESCRIPTION
### Description
* Fix expandable not showing for tournaments without registration
* Backmerge return sign fix from master branch
* Fix scalar slider dot overlapping upper bound

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-606

### Which PRs are linked to my PR?
* https://github.com/gnosis/pm-trading-ui/pull/335

### Which Steps did I take to verify my PR?
Tried to buy tokens on multiple scalar markets to check that overlapping doesn't happen again, tried different investment values to check return sign and visited market details page with locked/unlocked metamask to check expandable show condition

### Before and after
![image](https://user-images.githubusercontent.com/16622558/40317386-62881afe-5d32-11e8-9421-bc1913dbd6b8.png)

![screen shot 2018-05-21 at 20 05 31](https://user-images.githubusercontent.com/16622558/40317376-5a2ad090-5d32-11e8-9fe6-c2c0702da2f2.png)




