### PR TITLE
Bug PM-608: The filters doesn't remain through the navigation

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.dev.gnosisdev.com",
+    "host": "tradingdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/config/environments/development/config.json
+++ b/config/environments/development/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.staging.gnosisdev.com",
+    "host": "tradingdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/config/environments/local/config.json
+++ b/config/environments/local/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.staging.gnosisdev.com",
+    "host": "tradingdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/config/environments/olympia/development/config.json
+++ b/config/environments/olympia/development/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.staging.gnosisdev.com",
+    "host": "tradingdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/config/environments/staging/config.json
+++ b/config/environments/staging/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.staging.gnosisdev.com",
+    "host": "tradingdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/src/routes/MarketList/components/Filter/Form.js
+++ b/src/routes/MarketList/components/Filter/Form.js
@@ -66,4 +66,5 @@ Form.defaultProps = {
 
 export default reduxForm({
   form: MARKETFILTER_FORM_NAME,
+  destroyOnUnmount: false,
 })(Form)


### PR DESCRIPTION
### Description
* Set `destroyOnUnmount` to false for market list filter form
* Use new gnosisdb link: `tradingdb.staging.gnosisdev.com`

### Which Tickets does my PR fix? (Put in title too)
* Fixes BUG/PM-608

### Which PRs are linked to my PR?
* https://github.com/gnosis/pm-trading-ui/pull/347

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

I had chose different filters, then left the page and went back, the filters weren't reset