### PR TITLE
Bug PM-608: The filters doesn't remain through the navigation dev

### DIFF
--- a/src/routes/MarketList/components/Filter/Form.js
+++ b/src/routes/MarketList/components/Filter/Form.js
@@ -79,4 +79,5 @@ Form.defaultProps = {
 
 export default reduxForm({
   form: MARKETFILTER_FORM_NAME,
+  destroyOnUnmount: false,
 })(Form)


### PR DESCRIPTION
### Description
* Set `destroyOnUnmount` to false for market list filter form

### Which Tickets does my PR fix? (Put in title too)
* Fixes BUG/PM-608

### Which PRs are linked to my PR?
* https://github.com/gnosis/pm-trading-ui/pull/346

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

I had chose different filters, then left the page and went back, the filters weren't reset