### PR TITLE
[BACKMERGE] Bug/PM-467: Add Loading Spinners to fields that show gas estimations …

### DIFF
--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
@@ -11,6 +11,7 @@ import InteractionButton from 'containers/InteractionButton'
 import DecimalValue from 'components/DecimalValue'
 import CurrencyName from 'components/CurrencyName'
 import { TextInput, TextInputAdornment } from 'components/Form'
+import IndefiniteSpinner from 'components/Spinner/Indefinite'
 import { getOutcomeTokenCount, getMaximumWin, getPercentageWin } from './utils'
 import OutcomeSection from './OutcomesSection'
 import SubmitError from './SubmitError'
@@ -84,6 +85,8 @@ class MarketBuySharesForm extends Component {
     const {
       gasCosts,
       gasPrice,
+      isGasCostFetched,
+      isGasPriceFetched,
       invalid,
       handleSubmit,
       market: { event: { collateralToken, type }, local },
@@ -178,8 +181,14 @@ class MarketBuySharesForm extends Component {
               <div className={cx('row', 'infoRow')}>
                 <div className={cx('col-md-6')}>Gas Costs</div>
                 <div className={cx('col-md-6')}>
-                  <DecimalValue value={gasCostEstimation} decimals={4} />
-                  {' ETH'}
+                  {isGasPriceFetched && isGasCostFetched(GAS_COST.BUY_SHARES) ? (
+                    <React.Fragment>
+                      <DecimalValue value={gasCostEstimation} decimals={4} />
+                      <CurrencyName tokenAddress={market.event.collateralToken} />
+                    </React.Fragment>
+                  ) : (
+                    <IndefiniteSpinner width={16} height={16} />
+                  )}
                 </div>
               </div>
               <LimitMarginAnnotation />

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareSellView/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareSellView/index.js
@@ -13,8 +13,9 @@ import CurrencyName from 'components/CurrencyName'
 import { Slider, TextInput } from 'components/Form'
 import { NUMBER_REGEXP } from 'routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm'
 import Hairline from 'components/layout/Hairline'
+import IndefiniteSpinner from 'components/Spinner/Indefinite'
 import { marketShape, marketShareShape } from 'utils/shapes'
-import { LIMIT_MARGIN_DEFAULT, OUTCOME_TYPES } from 'utils/constants'
+import { LIMIT_MARGIN_DEFAULT, OUTCOME_TYPES, GAS_COST } from 'utils/constants'
 import { weiToEth, normalizeScalarPoint } from 'utils/helpers'
 import { calculateCurrentProbability, calculateEarnings, calculateNewProbability } from './utils'
 import style from './ShareSellView.mod.scss'
@@ -67,6 +68,8 @@ class ShareSellView extends Component {
       share,
       gasCosts,
       gasPrice,
+      isGasPriceFetched,
+      isGasCostFetched,
       valid,
     } = this.props
 
@@ -160,8 +163,14 @@ class ShareSellView extends Component {
                 <div className={cx('col-md-3', 'sellColumn')}>
                   <label>Gas costs</label>
                   <span>
-                    <DecimalValue value={gasCostEstimation} decimals={5} />&nbsp;
-                    <CurrencyName tokenAddress={market.event.collateralToken} />
+                    {isGasPriceFetched && isGasCostFetched(GAS_COST.SELL_SHARES) ? (
+                      <React.Fragment>
+                        <DecimalValue value={gasCostEstimation} decimals={5} />&nbsp;
+                        <CurrencyName tokenAddress={market.event.collateralToken} />
+                      </React.Fragment>
+                    ) : (
+                      <IndefiniteSpinner width={16} height={16} />
+                    )}
                   </span>
                 </div>
               </div>
@@ -219,8 +228,10 @@ class ShareSellView extends Component {
 
 ShareSellView.propTypes = {
   ...propTypes,
+  isGasCostFetched: PropTypes.func.isRequired,
   gasCosts: ImmutablePropTypes.map,
   gasPrice: PropTypes.instanceOf(Decimal),
+  isGasPriceFetched: PropTypes.bool,
   market: marketShape,
   selectedSellAmount: PropTypes.string,
   handleSellShare: PropTypes.func,
@@ -234,6 +245,7 @@ ShareSellView.defaultProps = {
   selectedSellAmount: undefined,
   handleSellShare: () => {},
   share: {},
+  isGasPriceFetched: false,
 }
 
 const FORM = {

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/index.js
@@ -55,6 +55,8 @@ class SharesTable extends Component {
       match: {
         params: { shareId: extendedShareId },
       },
+      isGasCostFetched,
+      isGasPriceFetched,
     } = this.props
     const tableRows = []
 
@@ -84,6 +86,8 @@ class SharesTable extends Component {
           market={market}
           gasCosts={gasCosts}
           gasPrice={gasPrice}
+          isGasCostFetched={isGasCostFetched}
+          isGasPriceFetched={isGasPriceFetched}
           selectedSellAmount={selectedSellAmount}
           handleSellShare={this.handleSellShare}
         />)
@@ -115,6 +119,8 @@ SharesTable.propTypes = {
   marketShares: PropTypes.objectOf(PropTypes.object),
   gasCosts: ImmutablePropTypes.map,
   gasPrice: PropTypes.instanceOf(Decimal),
+  isGasCostFetched: PropTypes.func.isRequired,
+  isGasPriceFetched: PropTypes.bool,
   selectedSellAmount: PropTypes.string,
   sellShares: PropTypes.func,
   match: ReactRouterMatchShape,
@@ -129,6 +135,7 @@ SharesTable.defaultProps = {
   selectedSellAmount: undefined,
   sellShares: () => {},
   match: {},
+  isGasPriceFetched: false,
 }
 
 export default SharesTable

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/index.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+import Decimal from 'decimal.js'
+
 import { marketShape } from 'utils/shapes'
 import { GAS_COST } from 'utils/constants'
 import SharesTable from './SharesTable'
@@ -53,10 +56,25 @@ MarketMySharesForm.propTypes = {
   selectedSellAmount: PropTypes.string,
   limitMargin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   marketShares: PropTypes.objectOf(PropTypes.object),
-  sellShares: PropTypes.func,
-  fetchMarketShares: PropTypes.func,
-  requestGasCost: PropTypes.func,
-  requestGasPrice: PropTypes.func,
+  sellShares: PropTypes.func.isRequired,
+  fetchMarketShares: PropTypes.func.isRequired,
+  requestGasCost: PropTypes.func.isRequired,
+  requestGasPrice: PropTypes.func.isRequired,
+  isGasCostFetched: PropTypes.func.isRequired,
+  isGasPriceFetched: PropTypes.bool,
+  gasCosts: ImmutablePropTypes.map,
+  gasPrice: PropTypes.instanceOf(Decimal),
+}
+
+MarketMySharesForm.defaultProps = {
+  defaultAccount: undefined,
+  market: undefined,
+  selectedSellAmount: '0',
+  limitMargin: '0',
+  marketShares: {},
+  isGasPriceFetched: false,
+  gasCosts: undefined,
+  gasPrice: undefined,
 }
 
 export default MarketMySharesForm

--- a/src/routes/MarketDetails/store/selectors/getGasCosts.js
+++ b/src/routes/MarketDetails/store/selectors/getGasCosts.js
@@ -3,7 +3,7 @@ const getGasCosts = (state) => {
 
   return gasCosts.map((cost) => {
     if (!cost) {
-      return 0
+      return undefined
     }
 
     return cost

--- a/src/routes/MarketDetails/store/selectors/getGasPrice.js
+++ b/src/routes/MarketDetails/store/selectors/getGasPrice.js
@@ -1,7 +1,12 @@
 import Decimal from 'decimal.js'
 
 const getGasPrice = (state) => {
-  const gasPrice = state.blockchain.get('gasPrice', 0)
+  const gasPrice = state.blockchain.get('gasPrice', undefined)
+
+  if (typeof gasPrice === 'undefined') {
+    return undefined
+  }
+
   let gasPriceDecimal
   try {
     gasPriceDecimal = Decimal(gasPrice.toString())

--- a/src/store/reducers/blockchain.js
+++ b/src/store/reducers/blockchain.js
@@ -10,7 +10,6 @@ import {
 import { setGasCost } from 'routes/MarketDetails/store/actions'
 
 import { GAS_COST } from 'utils/constants'
-import Decimal from 'decimal.js'
 
 const reducer = handleActions(
   {
@@ -28,8 +27,8 @@ const reducer = handleActions(
       state.setIn(['tokenBalances', tokenAddress], tokenBalance),
   },
   Map({
-    gasCosts: Object.keys(GAS_COST).reduce((acc, item) => acc.set(GAS_COST[item], '0'), Map()),
-    gasPrice: Decimal(0),
+    gasCosts: Object.keys(GAS_COST).reduce((acc, item) => acc.set(GAS_COST[item], undefined), Map()),
+    gasPrice: undefined,
     connection: undefined,
     connectionTried: false,
     tokenSymbols: Map(),

--- a/src/store/selectors/blockchain.spec.js
+++ b/src/store/selectors/blockchain.spec.js
@@ -43,10 +43,10 @@ describe('Blockchain selectors', () => {
       expect(isGasCostFetched(state)).toEqual(false)
     })
 
-    it('Should return falsy value if gasCost prop is not set', () => {
+    it('Should return false value if gasCost prop is not set', () => {
       const state = { blockchain: Map({ gasCosts: Map() }) }
 
-      expect(isGasCostFetched(state)).toBeFalsy()
+      expect(isGasCostFetched(state)).toEqual(false)
     })
 
     it('Should return true if gasCost for a prop is set', () => {
@@ -58,10 +58,10 @@ describe('Blockchain selectors', () => {
   })
 
   describe('getGasCosts', () => {
-    it('Should return gasCosts without falsy values and replace falsy values with 0', () => {
+    it('Should return gasCosts and if no gasCost is found, return undefined', () => {
       const buySharesGasCost = '500000'
       const sellSharesGasCost = '55405300'
-      const falsyValueReplacement = 0
+
       const state = {
         blockchain: Map({
           gasCosts: Map({ buyShares: buySharesGasCost, sellShares: sellSharesGasCost, market: undefined }),
@@ -72,7 +72,7 @@ describe('Blockchain selectors', () => {
       expect(gasCosts.size).toEqual(3)
       expect(gasCosts.get('buyShares', buySharesGasCost)).toEqual(buySharesGasCost)
       expect(gasCosts.get('sellShares', sellSharesGasCost)).toEqual(sellSharesGasCost)
-      expect(gasCosts.get('market')).toEqual(falsyValueReplacement)
+      expect(gasCosts.get('market')).toBeUndefined()
     })
 
     it('Should return an empty map when there are no gas costs set', () => {
@@ -126,7 +126,7 @@ describe('Blockchain selectors', () => {
   })
 
   describe('isGasPriceFetched', () => {
-    it('Should return false if gas price is undefined', () => {
+    it('Should return false if no gas price is fetched yet', () => {
       const state = {
         blockchain: Map({
           gasPrice: undefined,
@@ -136,7 +136,7 @@ describe('Blockchain selectors', () => {
       expect(isGasPriceFetched(state)).toEqual(false)
     })
 
-    it('Should return true if gas price is undefined', () => {
+    it('Should return true if gas price is defined', () => {
       const state = {
         blockchain: Map({
           gasPrice: '12345678',
@@ -148,14 +148,14 @@ describe('Blockchain selectors', () => {
   })
 
   describe('getGasPrice', () => {
-    it('Should return 0 if gas price is undefined', () => {
+    it('Should return undefined if no gas price is fetched yet', () => {
       const state = {
         blockchain: Map({
           gasPrice: undefined,
         }),
       }
 
-      expect(getGasPrice(state).toString()).toEqual('0')
+      expect(getGasPrice(state)).toBeUndefined()
     })
 
     it('Should return 0 if gas price is not a number', () => {


### PR DESCRIPTION
…(#339)

* PM-467: add loading spinner to gas cost display

* PM-467: fix tests to allow undefined as gascost/price values

### Description
* Example Content

### Which Tickets does my PR fix? (Put in title too)
* Fixes task/PM-123

### Which PRs are linked to my PR?
* task/PM-123

### Which side effects could my PR have?
* Example Content

### Which Steps did I take to verify my PR?

*Case 1*
* Example Content

*Case 2*
* Example Content

### Background Information
* Example Content

### Configuration Entries
`/staging/interface.config`
```
{
  "feature": {
    "enabled": false,
  }
}
```
`/olympia/staging/interface.config`
```
{
  "feature": {
    "enabled" true,
  }
}
```
