### PR TITLE
[BACKMERGE] Bug PM-625: Interface goes blank after selecting market and then logging in

### DIFF
--- a/src/containers/App/app.mod.scss
+++ b/src/containers/App/app.mod.scss
@@ -4,7 +4,7 @@ $footer-bottom: 44px;
 
 .appContainer {
   background-color: $bg-color;
-  min-height: calc(100vh - $footer-bottom);
+  height: calc(100vh - #{$footer-bottom});
 
   padding-bottom: $footer-bottom;
 

--- a/src/containers/InteractionButton/index.js
+++ b/src/containers/InteractionButton/index.js
@@ -51,6 +51,7 @@ class InteractionButton extends Component {
       loading,
       termsNotRequiredOrAccepted,
     } = this.props
+    console.log(targetNetworkId)
     if (whitelistRequired && !whitelisted) {
       return null
     }
@@ -118,7 +119,7 @@ class InteractionButton extends Component {
     }
 
     if (networkError) {
-      const wrongNetworkText = `You are connected to the wrong ethereum network. You can only interact using ${upperFirst(ETHEREUM_NETWORK_IDS[targetNetworkId].toLowerCase())} network.`
+      const wrongNetworkText = `You are connected to the wrong ethereum network. You can only interact using ${upperFirst((ETHEREUM_NETWORK_IDS[targetNetworkId] || '').toLowerCase())} network.`
       return <Tooltip overlay={wrongNetworkText}>{btn}</Tooltip>
     }
 

--- a/src/containers/InteractionButton/index.js
+++ b/src/containers/InteractionButton/index.js
@@ -51,7 +51,7 @@ class InteractionButton extends Component {
       loading,
       termsNotRequiredOrAccepted,
     } = this.props
-    console.log(targetNetworkId)
+
     if (whitelistRequired && !whitelisted) {
       return null
     }
@@ -111,11 +111,17 @@ class InteractionButton extends Component {
     }
 
     if (termsAndConditionsError) {
-      return <Tooltip overlay="You need to accept our terms and conditions before you can with this application.">{btn}</Tooltip>
+      return (
+        <Tooltip overlay="You need to accept our terms and conditions before you can with this application.">
+          {btn}
+        </Tooltip>
+      )
     }
 
     if (walletError) {
-      return <Tooltip overlay="You need a wallet connected before you can interact with this application.">{btn}</Tooltip>
+      return (
+        <Tooltip overlay="You need a wallet connected before you can interact with this application.">{btn}</Tooltip>
+      )
     }
 
     if (networkError) {


### PR DESCRIPTION
### Description
* In come cases, `web3.eth.net.getId()` returns 0. So, targetNetworkId = 0, we don't have a network name for id 0 in `ETHEREUM_NETWORK_IDS`. This results to a reference to `undefined` and then we try to call `.toLowerCase()` and it throws an error
* Use an empty string in case `ETHEREUM_NETWORK_IDS[targetNetworkId]` is undefined
* Minor codestyle fixes
* Fix loader position

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-625

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

I tried to reproduce the bug from a ticket and I haven't succeeded.