### PR TITLE
[BACKMERGE] BUG: Fix marketStatus utils to use moment's utc correctly

### DIFF
--- a/src/store/utils/marketStatus.js
+++ b/src/store/utils/marketStatus.js
@@ -12,8 +12,7 @@ export const isMarketClosed = (stage, resolutionDate, resolved) => {
 
 export const isMarketEndingSoon = (resolutionDate) => {
   const threeDays = moment.utc().add(3, 'days')
-
-  return moment.utc(resolutionDate).isBefore(threeDays)
+  return moment.utc(resolutionDate).isSameOrBefore(threeDays)
 }
 
 export const isNewMarket = (creation) => {

--- a/src/store/utils/marketStatus.js
+++ b/src/store/utils/marketStatus.js
@@ -3,7 +3,7 @@ import { MARKET_STAGES } from 'store/models'
 
 export const isMarketClosed = (stage, resolutionDate, resolved) => {
   const stageClosed = stage !== MARKET_STAGES.MARKET_FUNDED
-  const marketExpired = moment.utc(resolutionDate).isBefore(moment().utc())
+  const marketExpired = moment.utc(resolutionDate).isBefore(moment.utc())
   const marketResolved = resolved === true
 
   const marketClosed = stageClosed || marketExpired || marketResolved
@@ -11,13 +11,13 @@ export const isMarketClosed = (stage, resolutionDate, resolved) => {
 }
 
 export const isMarketEndingSoon = (resolutionDate) => {
-  const threeDays = moment().add(3, 'days').utc()
+  const threeDays = moment.utc().add(3, 'days')
 
   return moment.utc(resolutionDate).isBefore(threeDays)
 }
 
 export const isNewMarket = (creation) => {
-  const threeDaysAgo = moment().subtract(3, 'days').utc()
+  const threeDaysAgo = moment.utc().subtract(3, 'days')
 
   return threeDaysAgo.isBefore(creation)
 }


### PR DESCRIPTION
### Description
* Example Content

### Which Tickets does my PR fix? (Put in title too)
* Fixes task/PM-123

### Which PRs are linked to my PR?
* task/PM-123

### Which side effects could my PR have?
* Example Content

### Which Steps did I take to verify my PR?

*Case 1*
* Example Content

*Case 2*
* Example Content

### Background Information
* Example Content

### Configuration Entries
`/staging/interface.config`
```
{
  "feature": {
    "enabled": false,
  }
}
```
`/olympia/staging/interface.config`
```
{
  "feature": {
    "enabled" true,
  }
}
```

1. 