### PR TITLE
BUG: Fix marketStatus utils to use moment's utc correctly

### DIFF
--- a/src/store/utils/marketStatus.js
+++ b/src/store/utils/marketStatus.js
@@ -12,8 +12,7 @@ export const isMarketClosed = (stage, resolutionDate, resolved) => {
 
 export const isMarketEndingSoon = (resolutionDate) => {
   const threeDays = moment.utc().add(3, 'days')
-
-  return moment.utc(resolutionDate).isBefore(threeDays)
+  return moment.utc(resolutionDate).isSameOrBefore(threeDays)
 }
 
 export const isNewMarket = (creation) => {

--- a/src/store/utils/marketStatus.js
+++ b/src/store/utils/marketStatus.js
@@ -3,7 +3,7 @@ import { MARKET_STAGES } from 'store/models'
 
 export const isMarketClosed = (stage, resolutionDate, resolved) => {
   const stageClosed = stage !== MARKET_STAGES.MARKET_FUNDED
-  const marketExpired = moment.utc(resolutionDate).isBefore(moment().utc())
+  const marketExpired = moment.utc(resolutionDate).isBefore(moment.utc())
   const marketResolved = resolved === true
 
   const marketClosed = stageClosed || marketExpired || marketResolved
@@ -11,13 +11,13 @@ export const isMarketClosed = (stage, resolutionDate, resolved) => {
 }
 
 export const isMarketEndingSoon = (resolutionDate) => {
-  const threeDays = moment().add(3, 'days').utc()
+  const threeDays = moment.utc().add(3, 'days')
 
   return moment.utc(resolutionDate).isBefore(threeDays)
 }
 
 export const isNewMarket = (creation) => {
-  const threeDaysAgo = moment().subtract(3, 'days').utc()
+  const threeDaysAgo = moment.utc().subtract(3, 'days')
 
   return threeDaysAgo.isBefore(creation)
 }


### PR DESCRIPTION
### Description
* Fixed usage of moment utc mode according to `moment.js` docs:
https://momentjs.com/docs/#/parsing/utc/
it should be `moment.utc()` instead of `moment().utc()`
* Use `isSameOrBefore` instead of `isBefore` for the case when resolution date is equal to `moment.utc().add('3 days')`

### Which side effects could my PR have?
* Maybe a failing test 😄 

### Which Steps did I take to verify my PR?

I ran the tests for 5 times and none failed
