### PR TITLE
BUG PM-638: Interface goes blank after rejecting buy tx

### DIFF
--- a/src/routes/MarketDetails/store/actions/buyShares.js
+++ b/src/routes/MarketDetails/store/actions/buyShares.js
@@ -80,7 +80,7 @@ const buyMarketShares = (market, outcomeIndex, outcomeTokenCount, cost) => async
     await dispatch(closeModal())
   } catch (e) {
     console.error(e)
-    await dispatch(closeEntryError(transactionId, TRANSACTION_STAGES.GENERIC, e))
+    await dispatch(closeEntryError(transactionId, TRANSACTION_STAGES.GENERIC, e.message))
     await dispatch(closeLog(transactionId, TRANSACTION_COMPLETE_STATUS.ERROR))
     await dispatch(closeModal())
     throw e


### PR DESCRIPTION
### Description
* The error was  `TypeError: Converting circular structure to JSON` as a result of calling `JSON.stringify` on error object. I changed the action to pass only `.message` and not the whole object itself

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-638

### Which side effects could my PR have?
* Can't think of any

### Which Steps did I take to verify my PR?
I tried to buy shares and rejected the buy tx. The interface didn't crash


