### PR TITLE
Bug PM-614: Modal close button has ugly outline effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "redux": "^4.0.0",
     "redux-actions": "^2.4.0",
     "redux-form": "^7.1.2",
-    "redux-thunk": "^2.2.0",
+    "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1",
     "seedrandom": "^2.4.3",
     "sha1": "^1.1.1",
@@ -105,7 +105,7 @@
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-optional-chaining": "^7.0.0-beta.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
-    "bootstrap-loader": "^2.1.0",
+    "bootstrap-loader": "^3.0.0",
     "bootstrap-sass": "^3.3.7",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "copy-webpack-plugin": "^4.5.1",
@@ -135,7 +135,7 @@
     "truffle-hdwallet-provider": "0.0.5",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^1.0.1",
-    "webpack": "^4.9.1",
+    "webpack": "^4.10.0",
     "webpack-cli": "^2.1.4",
     "webpack-dev-server": "^3.1.4"
   }

--- a/src/components/ModalContent/UnlockMetamask/UnlockMetamask.mod.scss
+++ b/src/components/ModalContent/UnlockMetamask/UnlockMetamask.mod.scss
@@ -10,9 +10,9 @@
   color: #fff;
 
   .heading {
-      font-size: 21px;
-      margin: 33px 0px 20px 0px;
-      font-weight: 500;
+    font-size: 21px;
+    margin: 33px 0px 20px 0px;
+    font-weight: 500;
   }
 
   .text {
@@ -28,9 +28,10 @@
     border: none;
 
     &:hover {
-        &::after, &::before {
-          background-color: #fff;
-        }
+      &::after,
+      &::before {
+        background-color: #fff;
       }
+    }
   }
 }

--- a/src/scss/vars.scss
+++ b/src/scss/vars.scss
@@ -81,11 +81,15 @@ $paddings-inputs: 5px 0;
     transform: rotate(-45deg);  
   }
 
-  &:hover {
+  &:hover, &:focus {
     &::after, &::before {
       background-color: $active-highlight;
       background-color: $active-highlight;
     }
+  }
+
+  &:focus {
+    outline: none;
   }
 }
 


### PR DESCRIPTION
### Description
* Update `redux-thunk`, `webpack`, `bootstrap-loader`
* Set outline to none when the button is focused
* Fix unlock metamask modal scss codestyle
* A focused button has the same effect as hovered one

### Which Tickets does my PR fix? (Put in title too)
* Fixes Bug/PM-614

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

Checked styles of focused button in different modals

### Before and after:
<img width="379" alt="screen shot 2018-05-29 at 15 38 32" src="https://user-images.githubusercontent.com/16622558/40656739-6789543a-6356-11e8-89e8-b30017596202.png">
<img width="384" alt="screen shot 2018-05-29 at 15 37 50" src="https://user-images.githubusercontent.com/16622558/40656738-67662708-6356-11e8-87b0-e298b7d27709.png">
