### PR TITLE
Bug Hotfix: Error on unregistered accounts viewing the site

### DIFF
--- a/src/routes/Scoreboard/store/actions/fetchTournamentUserData.js
+++ b/src/routes/Scoreboard/store/actions/fetchTournamentUserData.js
@@ -3,8 +3,9 @@ import addUsers from './addUsers'
 
 export default account => dispatch =>
   requestFromRestAPI(`scoreboard/${account}`).then((response) => {
-    if (!response) {
+    if (!response || response.detail === 'Not found.') {
       dispatch(addUsers([]))
+      return
     }
 
     dispatch(addUsers([response]))

--- a/src/routes/Scoreboard/store/actions/fetchTournamentUsers.js
+++ b/src/routes/Scoreboard/store/actions/fetchTournamentUsers.js
@@ -5,6 +5,7 @@ export default () => dispatch =>
   requestFromRestAPI('scoreboard').then((response) => {
     if (!response) {
       dispatch(addUsers([]))
+      return
     }
 
     dispatch(addUsers(response.results))

--- a/src/routes/Scoreboard/store/selectors/index.js
+++ b/src/routes/Scoreboard/store/selectors/index.js
@@ -44,7 +44,7 @@ export const tournamentMainnetRegistryAddress = (state) => {
 export const meSelector = createSelector(
   tournamentUsersSelectorAsList,
   getCurrentAccount,
-  (users, account) => (users && users.size && account ? users.find(user => normalizeHex(user.account || '') === normalizeHex(account)) : undefined),
+  (users, account) => (users && account ? users.find(user => normalizeHex(user.account) === normalizeHex(account)) : undefined),
 )
 
 export const areRewardsClaimed = state => state.tournament.rewards.get('rewardsClaimed')

--- a/src/routes/Scoreboard/store/selectors/index.js
+++ b/src/routes/Scoreboard/store/selectors/index.js
@@ -44,7 +44,7 @@ export const tournamentMainnetRegistryAddress = (state) => {
 export const meSelector = createSelector(
   tournamentUsersSelectorAsList,
   getCurrentAccount,
-  (users, account) => (users && account ? users.find(user => normalizeHex(user.account) === normalizeHex(account)) : undefined),
+  (users, account) => (users && users.size && account ? users.find(user => normalizeHex(user.account || '') === normalizeHex(account)) : undefined),
 )
 
 export const areRewardsClaimed = state => state.tournament.rewards.get('rewardsClaimed')


### PR DESCRIPTION
### Description
* Site crash fix when users who are not registered view the page.

### Which Tickets does my PR fix? (Put in title too)
* /

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* /

### Which Steps did I take to verify my PR?

*Viewed Page as unregistered user*
* Worked, no more errors

### Background Information
* `normalizeHex` was introduced to deal with inconsistencies between trading-db, ethereum and other sources for addresses

### Configuration Entries
/