### PR TITLE
Bug PM-710: The interface sometimes forgets that the wallet is registered until you refresh the page

### DIFF
--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -20,6 +20,24 @@ const addOlympiaContracts = async (gnosisJsInstance) => {
   })
 }
 
+const waitForGnosisConnection = instance => new Promise((resolve, reject) => {
+  let stillRunning = true
+  const instanceCheck = setInterval(() => {
+    if (instance) {
+      stillRunning = false
+      clearInterval(instanceCheck)
+      return resolve(instance)
+    }
+  }, 50)
+
+  setTimeout(() => {
+    if (stillRunning) {
+      clearInterval(instanceCheck)
+      reject(new Error('Connection to RO Gnosis.js timed out'))
+    }
+  }, NETWORK_TIMEOUT)
+})
+
 /**
  * Initializes connection to GnosisJS
  * @param {*dictionary} GNOSIS_OPTIONS
@@ -74,25 +92,15 @@ export const getGnosisConnection = async () => {
     return gnosisInstance
   }
 
-  return new Promise((resolve, reject) => {
-    let stillRunning = true
-    const instanceCheck = setInterval(() => {
-      if (gnosisInstance) {
-        stillRunning = false
-        clearInterval(instanceCheck)
-        return resolve(gnosisInstance)
-      }
-    }, 50)
-
-    setTimeout(() => {
-      if (stillRunning) {
-        clearInterval(instanceCheck)
-        reject(new Error('Connection to Gnosis.js timed out'))
-      }
-    }, NETWORK_TIMEOUT)
-  })
+  return waitForGnosisConnection(gnosisInstance)
 }
 
-export const getROGnosisConnection = async () => gnosisROInstance || undefined
+export const getROGnosisConnection = async () => {
+  if (gnosisROInstance) {
+    return gnosisROInstance
+  }
+
+  return waitForGnosisConnection(gnosisROInstance)
+}
 
 export default Gnosis


### PR DESCRIPTION
### Description
The error was because it was trying to read `.contracts` of uninitialized gnosis.js read-only connection. I moved a promise from `getGnosisConnection` to a function where we can pass an instance and wait for it to load  

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-710

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

Refreshed the page like 15 times and it always logged me in