### PR TITLE
BUG PM-712: User is registered after rejecting Metamask pop up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,6 +1337,12 @@
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
@@ -1390,6 +1396,78 @@
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "css-loader": {
+          "version": "0.28.11",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+          "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "css-selector-tokenizer": "^0.7.0",
+            "cssnano": "^3.10.0",
+            "icss-utils": "^2.1.0",
+            "loader-utils": "^1.0.2",
+            "lodash.camelcase": "^4.3.0",
+            "object-assign": "^4.1.1",
+            "postcss": "^5.0.6",
+            "postcss-modules-extract-imports": "^1.2.0",
+            "postcss-modules-local-by-default": "^1.2.0",
+            "postcss-modules-scope": "^1.1.0",
+            "postcss-modules-values": "^1.3.0",
+            "postcss-value-parser": "^3.3.0",
+            "source-list-map": "^2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "5.2.18",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+              "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+              "dev": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
+              }
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -5191,9 +5269,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000864",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000864.tgz",
-      "integrity": "sha1-NaSyMlqNRVOka1FtvCM785HXVVU=",
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000865.tgz",
+      "integrity": "sha1-gv+2TUD3VnYgqsAtOmMgeWiavGs=",
       "dev": true
     },
     "caniuse-lite": {
@@ -6110,96 +6188,23 @@
       }
     },
     "css-loader": {
-      "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
-      "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
+      "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "css-selector-tokenizer": "^0.7.0",
-        "cssnano": "^3.10.0",
         "icss-utils": "^2.1.0",
         "loader-utils": "^1.0.2",
         "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.1.1",
-        "postcss": "^5.0.6",
+        "postcss": "^6.0.23",
         "postcss-modules-extract-imports": "^1.2.0",
         "postcss-modules-local-by-default": "^1.2.0",
         "postcss-modules-scope": "^1.1.0",
         "postcss-modules-values": "^1.3.0",
         "postcss-value-parser": "^3.3.0",
         "source-list-map": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "css-select": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "bootstrap-sass": "^3.3.7",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "copy-webpack-plugin": "^4.5.2",
-    "css-loader": "^0.28.11",
+    "css-loader": "^1.0.0",
     "eslint": "^5.0.1",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-loader": "^2.0.0",

--- a/src/components/ModalContent/RegisterWallet/index.js
+++ b/src/components/ModalContent/RegisterWallet/index.js
@@ -126,5 +126,5 @@ export default lifecycle({
     if (this.props.mainnetAddress) {
       this.props.closeModal()
     }
-  }
+  },
 })(RegisterMainnetAddress)

--- a/src/components/ModalContent/RegisterWallet/index.js
+++ b/src/components/ModalContent/RegisterWallet/index.js
@@ -42,22 +42,22 @@ const RegisterMainnetAddress = ({
       <button className={cx('closeButton')} onClick={closeModal} />
       <div className={cx('registerContainer')}>
         <h4 className={cx('heading')}>
-Register wallet address
+          Register wallet address
         </h4>
         <p className={cx('annotation')}>
           Please register your wallet address, where we can send you
           {' '}
           {collateralTokenSymbol}
           {' '}
-tokens, and subsequently
+          tokens, and subsequently
           your
           {' '}
           {rewardTokenSymbol}
           {' '}
-reward. Read our terms of service for more information
+          reward. Read our terms of service for more information
         </p>
         <p className={cx('walletAnnotation')}>
-Your current Metamask address is:
+          Your current Metamask address is:
         </p>
         <div className={cx('walletAddressContainer')}>
           <img src={WalletIcon} className={cx('walletIcon')} alt="" />
@@ -69,11 +69,11 @@ Your current Metamask address is:
           You need Rinkeby ETH to register your wallet address.
           {' '}
           <br />
-Rinkeby ETH balance:
+          Rinkeby ETH balance:
           {' '}
           <DecimalValue value={currentBalance} className={cx('walletBalance')} />
           {' '}
--
+          -
           {' '}
           <a className={cx('faucetLink')} href="https://faucet.rinkeby.io/" target="_blank" rel="noopener noreferrer">
             Request Rinkeby Ether
@@ -108,11 +108,13 @@ RegisterMainnetAddress.propTypes = {
   collateralToken: PropTypes.shape({
     symbol: PropTypes.string,
   }).isRequired,
+  mainnetAddress: PropTypes.string,
 }
 
 RegisterMainnetAddress.defaultProps = {
   gasPrice: Decimal(0),
   registrationGasCost: 0,
+  mainnetAddress: undefined,
 }
 
 export default lifecycle({
@@ -120,4 +122,9 @@ export default lifecycle({
     this.props.requestRegistrationGasCost()
     this.props.requestGasPrice()
   },
+  componentDidUpdate() {
+    if (this.props.mainnetAddress) {
+      this.props.closeModal()
+    }
+  }
 })(RegisterMainnetAddress)

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -12,7 +12,7 @@ import Footer from 'components/Footer'
 import { providerPropType } from 'utils/shapes'
 import HeaderContainer from 'containers/HeaderContainer'
 import TransactionFloaterContainer from 'containers/TransactionFloaterContainer'
-import { triedToConnect } from 'store/selectors/blockchain'
+import { isConnectedToBlockchain } from 'store/selectors/blockchain'
 import { getActiveProvider, isConnectedToCorrectNetwork } from 'integrations/store/selectors'
 import 'normalize.css'
 
@@ -22,12 +22,17 @@ import transitionStyles from './transitions.mod.scss'
 const cx = cn.bind(style)
 
 const App = (props) => {
-  if (!props.blockchainConnection) {
+  const {
+    provider, blockchainConnection, children, location,
+  } = props
+  if (!blockchainConnection) {
     return (
       <div className={cx('appContainer')}>
         <div className={cx('loader-container')}>
           <IndefiniteSpinner width={100} height={100} />
-          <h1>Connecting</h1>
+          <h1>
+            Connecting to the blockchain
+          </h1>
         </div>
       </div>
     )
@@ -44,10 +49,10 @@ const App = (props) => {
   return (
     <div className={cx('appContainer')}>
       <HeaderContainer version={process.env.VERSION} />
-      {props.provider && props.provider.account && <TransactionFloaterContainer />}
+      {provider && provider.account && <TransactionFloaterContainer />}
       <TransitionGroup>
-        <CSSTransition key={props.location.pathname.split('/')[1]} classNames={transitionClassNames} timeout={timeout}>
-          {props.children}
+        <CSSTransition key={location.pathname.split('/')[1]} classNames={transitionClassNames} timeout={timeout}>
+          {children}
         </CSSTransition>
       </TransitionGroup>
       <Footer />
@@ -76,10 +81,15 @@ App.defaultProps = {
 
 const mapStateToProps = state => ({
   provider: getActiveProvider(state),
-  blockchainConnection: triedToConnect(state),
+  blockchainConnection: isConnectedToBlockchain(state),
   isConnectedToCorrectNetwork: isConnectedToCorrectNetwork(state),
 })
 
-export default withRouter(connect(mapStateToProps, {
-  connectBlockchain,
-})(App))
+export default withRouter(
+  connect(
+    mapStateToProps,
+    {
+      connectBlockchain,
+    },
+  )(App),
+)

--- a/src/containers/BackdropProvider/index.js
+++ b/src/containers/BackdropProvider/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import cn from 'classnames/bind'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-import { triedToConnect } from 'store/selectors/blockchain'
+import { isConnectedToBlockchain } from 'store/selectors/blockchain'
 import { closeModal } from 'store/actions/modal'
 import * as modals from 'containers/Modals'
 import style from './backdrop.mod.scss'
@@ -65,7 +65,7 @@ BackdropProvider.propTypes = {
 
 const mapStateToProps = state => ({
   modal: state.modal,
-  blockchainConnection: triedToConnect(state),
+  blockchainConnection: isConnectedToBlockchain(state),
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/Modals/ModalRegisterWallet/index.js
+++ b/src/containers/Modals/ModalRegisterWallet/index.js
@@ -1,11 +1,10 @@
 import { connect } from 'react-redux'
-import { formValueSelector } from 'redux-form'
 import RegisterWallet from 'components/ModalContent/RegisterWallet'
 
 import { updateMainnetAddress } from 'store/actions/account'
 import { requestGasPrice } from 'store/actions/blockchain'
 import { getCollateralToken } from 'store/selectors/blockchain'
-import { getCurrentAccount, getCurrentBalance } from 'integrations/store/selectors'
+import { getCurrentAccount, getCurrentBalance, getRegisteredMainnetAddress } from 'integrations/store/selectors'
 import { setLegalDocumentsAccepted } from 'integrations/store/actions'
 import { getGasPrice } from 'routes/MarketDetails/store/selectors'
 import { requestRegistrationGasCost } from './actions'
@@ -17,6 +16,7 @@ const mapStateToProps = state => ({
   registrationGasCost: getRegistrationGasCost(state),
   gasPrice: getGasPrice(state),
   collateralToken: getCollateralToken(state),
+  mainnetAddress: getRegisteredMainnetAddress(state),
 })
 
 const mapDispatchToProps = {

--- a/src/store/reducers/blockchain.js
+++ b/src/store/reducers/blockchain.js
@@ -3,6 +3,7 @@ import { Map } from 'immutable'
 import {
   setConnectionStatus,
   setGnosisInitialized,
+  setGnosisROInitialized,
   setGasPrice,
   setTokenSymbol,
   setTokenBalance,
@@ -15,37 +16,36 @@ import { GAS_COST } from 'utils/constants'
 
 const reducer = handleActions(
   {
-    [setConnectionStatus]: (state, { payload: { connection } }) =>
-      state.withMutations((stateMap) => {
-        stateMap.set('connection', connection)
-        stateMap.set('connectionTried', true)
-      }),
+    [setConnectionStatus]: (state, { payload: { connection } }) => state.withMutations((stateMap) => {
+      stateMap.set('connection', connection)
+      stateMap.set('connectionTried', true)
+    }),
     [setGnosisInitialized]: (state, { payload: { initialized } }) => state.set('gnosisInitialized', initialized),
+    [setGnosisROInitialized]: (state, { payload: { initialized } }) => state.set('gnosisROInitialized', initialized),
     [setGasCost]: (state, { payload: { contractType, gasCost } }) => state.setIn(['gasCosts', contractType], gasCost),
     [setGasPrice]: (state, { payload: { entityType, gasPrice } }) => state.set(entityType, gasPrice),
-    [setTokenSymbol]: (state, { payload: { tokenAddress, tokenSymbol } }) =>
-      state.setIn(['tokenSymbols', tokenAddress], tokenSymbol),
-    [setTokenBalance]: (state, { payload: { tokenAddress, tokenBalance } }) =>
-      state.setIn(['tokenBalances', tokenAddress], tokenBalance),
+    [setTokenSymbol]: (state, { payload: { tokenAddress, tokenSymbol } }) => state.setIn(['tokenSymbols', tokenAddress], tokenSymbol),
+    [setTokenBalance]: (state, { payload: { tokenAddress, tokenBalance } }) => state.setIn(['tokenBalances', tokenAddress], tokenBalance),
     [setCollateralToken]: (state, {
       payload: {
+        address, symbol, icon, source,
+      },
+    }) => state.set(
+      'collateralToken',
+      Map({
         address,
         symbol,
         icon,
         source,
-      },
-    }) => state.set('collateralToken', Map({
-      address,
-      symbol,
-      icon,
-      source,
-    })),
+      }),
+    ),
   },
   Map({
     gasCosts: Object.keys(GAS_COST).reduce((acc, item) => acc.set(GAS_COST[item], undefined), Map()),
     gasPrice: undefined,
     connection: undefined,
-    connectionTried: false,
+    gnosisInitialized: false,
+    gnosisROInitialized: false,
     tokenSymbols: Map(),
     tokenBalances: Map(),
     collateralToken: Map({

--- a/src/store/selectors/blockchain.js
+++ b/src/store/selectors/blockchain.js
@@ -9,7 +9,7 @@ import { weiToEth } from 'utils/helpers'
  */
 export const isGnosisInitialized = state => !!state.blockchain.get('gnosisInitialized')
 
-export const triedToConnect = state => !!state.blockchain.get('connectionTried')
+export const isConnectedToBlockchain = state => !!state.blockchain.get('gnosisInitialized') && !!state.blockchain.get('gnosisROInitialized')
 
 export const isGasCostFetched = (state, property) => state.blockchain.getIn(['gasCosts', property]) !== undefined
 

--- a/src/store/selectors/blockchain.spec.js
+++ b/src/store/selectors/blockchain.spec.js
@@ -22,18 +22,18 @@ describe('Blockchain selectors', () => {
   })
 
   describe('isConnectedToBlockchain', () => {
-    it('Should return falsy if not tried to connect / Map doesnt have connectionTried key', () => {
-      const state = { blockchain: Map({ connectionTried: false }) }
+    it('Should return falsy if none or one of gnosis.js instances was initialized', () => {
+      const state = { blockchain: Map({ gnosisInitialized: false, gnosisROInitialized: false }) }
 
-      expect(isConnectedToBlockchain(state)).toBeFalsy()
-      state.blockchain.clear()
-      expect(isConnectedToBlockchain(state)).toBeFalsy()
+      expect(isConnectedToBlockchain(state)).toBe(false)
+      state.blockchain.set('gnosisInitialized', true)
+      expect(isConnectedToBlockchain(state)).toBe(false)
     })
 
-    it('Should return falsy if we tried to connect', () => {
-      const state = { blockchain: Map({ connectionTried: true }) }
+    it('Should return truthy value if both gnosis.js instances are initialized', () => {
+      const state = { blockchain: Map({ gnosisInitialized: true, gnosisROInitialized: true }) }
 
-      expect(isConnectedToBlockchain(state)).toBeTruthy()
+      expect(isConnectedToBlockchain(state)).toBe(true)
     })
   })
 

--- a/src/store/selectors/blockchain.spec.js
+++ b/src/store/selectors/blockchain.spec.js
@@ -1,4 +1,4 @@
-import { isGnosisInitialized, triedToConnect, getTokenAmount, getCollateralToken } from 'store/selectors/blockchain'
+import { isGnosisInitialized, isConnectedToBlockchain, getTokenAmount, getCollateralToken } from 'store/selectors/blockchain'
 import { getGasPrice, getGasCosts, isGasCostFetched, isGasPriceFetched } from 'routes/MarketDetails/store/selectors'
 import { ProviderRecord } from 'integrations/store/models'
 
@@ -21,19 +21,19 @@ describe('Blockchain selectors', () => {
     })
   })
 
-  describe('triedToConnect', () => {
+  describe('isConnectedToBlockchain', () => {
     it('Should return falsy if not tried to connect / Map doesnt have connectionTried key', () => {
       const state = { blockchain: Map({ connectionTried: false }) }
 
-      expect(triedToConnect(state)).toBeFalsy()
+      expect(isConnectedToBlockchain(state)).toBeFalsy()
       state.blockchain.clear()
-      expect(triedToConnect(state)).toBeFalsy()
+      expect(isConnectedToBlockchain(state)).toBeFalsy()
     })
 
     it('Should return falsy if we tried to connect', () => {
       const state = { blockchain: Map({ connectionTried: true }) }
 
-      expect(triedToConnect(state)).toBeTruthy()
+      expect(isConnectedToBlockchain(state)).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
### Description
* Remove `triedToConnect` because it's not reliable
* Add `isConnectedToBlockchain` to detect if both gnosis.js instances are initialized
* Close `registerWallet` modal if it turns out that user is already registered
* Codestyle fixes
* Update `css-loader`
* Change loader screen text to be more specific: from `Connecting` to `Connecting to the blockchain`

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-712

### Which side effects could my PR have?
* It's hard to say, maybe some problems with registration

### Which Steps did I take to verify my PR?

*Open register mainnet address modal with unregistered account, then switch to a registered one*

Modal closes.

### Background information

There were some problems with registration because gnosis.js read-only instance was initialized after we tried to get info from it. Now loader screen is shown until it is initialized. There are also one more bug with metamask integration that leaves the user not logged in. The bug is in `src/integrations/metamask/index.js`:

```
    return this.runProviderUpdate(this, {
      available: this.walletEnabled && !!this.account,
      networkId: this.networkId,
      network: this.network,
      account: this.account,
      balance: this.balance,
    })
```

Sometimes `available` is set to false, but I wasn't able to debug it properly. I tried to simulate slow network, high latency but it didn't help. Couldn't find the dependence 