### PR TITLE
Bug PM-738: Scoreboard styles are not imported

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -9,7 +9,7 @@ import CSSTransition from 'react-transition-group/CSSTransition'
 import IndefiniteSpinner from 'components/Spinner/Indefinite'
 import Footer from 'components/Footer'
 import { providerPropType } from 'utils/shapes'
-import { getHtmlConfig } from 'utils/features'
+import { getHtmlConfig, isFeatureEnabled } from 'utils/features'
 import HeaderContainer from 'containers/HeaderContainer'
 import TransactionFloaterContainer from 'containers/TransactionFloaterContainer'
 import { isConnectedToBlockchain } from 'store/selectors/blockchain'
@@ -20,6 +20,10 @@ import { lifecycle } from 'recompose'
 import style from './app.scss'
 import transitionStyles from './transitions.scss'
 import 'rc-tooltip/assets/bootstrap.css?raw'
+
+if (isFeatureEnabled('tournament')) {
+  import('react-table/react-table.css?raw')
+}
 
 const cx = cn.bind(style)
 


### PR DESCRIPTION
### Description
* Previously scoreboard's styles weren't imported and scoreboard looked weird

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-738

### Which side effects could my PR have?
* None

### Which Steps did I take to verify my PR?

Checked that scoreboard shows fine

### Before and after:
<img width="1180" alt="screen shot 2018-08-02 at 16 14 02" src="https://user-images.githubusercontent.com/16622558/43583011-42f262c8-966f-11e8-83e3-ef4a89c21c4a.png">
<img width="1235" alt="screen shot 2018-08-02 at 16 13 23" src="https://user-images.githubusercontent.com/16622558/43583010-42c9bad0-966f-11e8-897a-7fc333be944f.png">
