### PR TITLE
Isolate embedded components to reduce bundle size and decrease build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "truffle-hdwallet-provider": "0.0.6",
     "url-loader": "^1.1.1",
     "webpack": "^4.27.0",
+    "webpack-cli": "^3.0.4",
     "webpack-dev-server": "^3.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "truffle-hdwallet-provider": "0.0.6",
     "url-loader": "^1.1.1",
     "webpack": "^4.27.0",
-    "webpack-cli": "^3.0.4",
     "webpack-dev-server": "^3.1.4"
   }
 }

--- a/src/embedded/routes/EmbeddedView/api/index.js
+++ b/src/embedded/routes/EmbeddedView/api/index.js
@@ -1,5 +1,17 @@
 import { requestFromRestAPI } from 'api/utils/fetch'
-import { extractMarkets } from 'store/actions/market/fetchMarkets'
+import builderFunctions from './marketBuilders'
+
+const extractMarkets = markets => markets.map((market) => {
+  const marketType = market.event.type
+
+  const builder = builderFunctions[marketType]
+
+  if (!builder) {
+    throw new Error(`No builder function associated with type '${marketType}'`)
+  }
+
+  return builder.call(builder, market)
+})
 
 export const getMarketById = async (marketAddress) => {
   const response = await requestFromRestAPI(`markets/${marketAddress}`)

--- a/src/embedded/routes/EmbeddedView/api/marketBuilders.js
+++ b/src/embedded/routes/EmbeddedView/api/marketBuilders.js
@@ -1,0 +1,143 @@
+import { List } from 'immutable'
+import {
+  BoundsRecord, CategoricalMarketRecord, ScalarMarketRecord, OutcomeRecord,
+} from 'store/models'
+import { isMarketClosed } from 'store/utils/marketStatus'
+import { OUTCOME_TYPES } from 'utils/constants'
+
+const buildOutcomesFrom = (outcomes, outcomeTokensSold, marginalPrices) => {
+  if (!outcomes) {
+    return List([])
+  }
+
+  const outcomesRecords = outcomes.map((outcome, index) => new OutcomeRecord({
+    name: outcome,
+    index,
+    marginalPrice: marginalPrices[index],
+    outcomeTokensSold: outcomeTokensSold[index],
+  }))
+
+  return List(outcomesRecords)
+}
+
+const buildBoundsFrom = (lower, upper, unit, decimals) => BoundsRecord({
+  lower,
+  upper,
+  unit,
+  decimals: parseInt(decimals, 10),
+})
+
+const buildScalarMarket = (market) => {
+  const {
+    stage,
+    contract: { address, creationDate, creator },
+    tradingVolume,
+    funding,
+    netOutcomeTokensSold,
+    fee,
+    event: {
+      contract: { address: eventAddress },
+      type,
+      collateralToken,
+      lowerBound,
+      upperBound,
+      isWinningOutcomeSet,
+      oracle: {
+        isOutcomeSet,
+        outcome,
+        eventDescription: {
+          title, description, resolutionDate, unit, decimals,
+        },
+      },
+    },
+  } = market
+
+  const outcomesResponse = ['SHORT', 'LONG']
+
+  const outcomes = buildOutcomesFrom(outcomesResponse, netOutcomeTokensSold, market.marginalPrices)
+  const bounds = buildBoundsFrom(lowerBound, upperBound, unit, decimals)
+
+  const resolved = isOutcomeSet || isWinningOutcomeSet
+  const closed = isMarketClosed({ stage, resolution: resolutionDate })
+
+  const marketRecord = new ScalarMarketRecord({
+    title,
+    description,
+    creator,
+    collateralToken,
+    address,
+    stage,
+    type,
+    fee,
+    outcomes,
+    bounds,
+    eventAddress,
+    resolution: resolutionDate,
+    creation: creationDate,
+    volume: tradingVolume,
+    resolved,
+    closed,
+    winningOutcome: outcome,
+    funding: funding || 0,
+    outcomeTokensSold: List(netOutcomeTokensSold),
+  })
+
+  return marketRecord
+}
+
+const buildCategoricalMarket = (market) => {
+  const {
+    stage,
+    contract: { address, creationDate, creator },
+    tradingVolume,
+    funding,
+    fee,
+    netOutcomeTokensSold,
+    event: {
+      contract: { address: eventAddress },
+      type,
+      collateralToken,
+      isWinningOutcomeSet,
+      oracle: {
+        isOutcomeSet,
+        outcome: winningOutcomeIndex,
+        eventDescription: {
+          title, description, resolutionDate, outcomes: outcomeLabels,
+        },
+      },
+    },
+  } = market
+
+  const outcomes = buildOutcomesFrom(outcomeLabels, netOutcomeTokensSold, market.marginalPrices)
+
+  const resolved = isOutcomeSet || isWinningOutcomeSet
+  const closed = isMarketClosed({ stage, resolution: resolutionDate })
+
+  const marketRecord = new CategoricalMarketRecord({
+    title,
+    description,
+    creator,
+    collateralToken,
+    address,
+    stage,
+    type,
+    outcomes,
+    eventAddress,
+    resolution: resolutionDate,
+    creation: creationDate,
+    volume: tradingVolume,
+    resolved,
+    closed,
+    fee,
+    funding: funding || 0,
+    winningOutcome: outcomes.get(winningOutcomeIndex),
+    outcomeTokensSold: List(netOutcomeTokensSold),
+  })
+
+  return marketRecord
+}
+
+export default {
+  [OUTCOME_TYPES.CATEGORICAL]: buildCategoricalMarket,
+  [OUTCOME_TYPES.SCALAR]: buildScalarMarket,
+}

--- a/src/embedded/routes/EmbeddedView/components/Market/Market.scss
+++ b/src/embedded/routes/EmbeddedView/components/Market/Market.scss
@@ -1,0 +1,120 @@
+@import '~style/vars.scss';
+
+$market-border-radius: 12px;
+$market-highlight-stripe-width: 5px;
+$info-row-height: 25px;
+$expandable-arrow-size: 7px;
+$expandable-margin: 40px;
+
+.market {
+  width: 100%;
+  -webkit-appearance: none;
+  border: none;
+  display: block;
+  position: relative;
+  background-color: white;
+  padding: 20px 20px 10px 20px;
+  margin: 2px 0;
+  overflow: hidden;
+  text-align: left;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: $market-highlight-stripe-width;
+    background-color: $link-color;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .title {
+    margin: 0;
+    letter-spacing: 1px;
+    color: black;
+    font-weight: 400;
+    font-size: 22px;
+  }
+
+  &.resolved, &.closed {
+    .title {
+      color: $font-color-light;
+      opacity: 0.6;
+      font-weight: 300;
+    }
+  }
+
+  .resolve {
+    text-transform: uppercase;
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    color: $link-color;
+    &:hover, &:focus {
+      color: $link-color-highlight;
+    }
+    &:visited, &:active {
+      color: $link-color;
+    }
+  }
+
+  &:first-child {
+    border-top-left-radius: $market-border-radius;
+    border-top-right-radius: $market-border-radius;
+  }
+
+  &:last-child {
+    border-bottom-left-radius: $market-border-radius;
+    border-bottom-right-radius: $market-border-radius;
+  }
+
+  .info {
+    margin-top: 10px;
+  
+    .group {
+      display: inline-block;
+      color: darken($font-color-light, 30%);
+      opacity: 0.6;
+      font-weight: 500;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      font-size: 11px;
+      vertical-align: middle;
+
+      .title {
+        margin: 0;
+        text-transform: uppercase;
+        float: left;
+
+        &:after {
+          content: '';
+          display: table;
+          clear: both;
+        }
+      }
+
+    }
+  }
+}
+
+.marketInfo {
+  white-space: nowrap;
+  opacity: 0.6;
+
+  .label {
+    display: inline-block;
+    padding-left: 5px;
+
+    vertical-align: top;
+    line-height: $info-row-height;
+
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}

--- a/src/embedded/routes/EmbeddedView/components/Market/MarketResolution.js
+++ b/src/embedded/routes/EmbeddedView/components/Market/MarketResolution.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import classNames from 'classnames/bind'
+
+import Icon from 'components/Icon'
+
+import css from './Market.scss'
+
+const cx = classNames.bind(css)
+
+const MarketResolution = ({ resolution }) => (
+  <div className={cx('marketInfo')}>
+    <Icon type="enddate" size={25} />
+    <div className={cx('label')}>
+      {resolution}
+    </div>
+  </div>
+)
+
+MarketResolution.propTypes = {
+  resolution: PropTypes.string.isRequired,
+}
+
+export default MarketResolution

--- a/src/embedded/routes/EmbeddedView/components/Market/MarketStatus.js
+++ b/src/embedded/routes/EmbeddedView/components/Market/MarketStatus.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Countdown from 'components/Countdown'
+import classNames from 'classnames/bind'
+import { RESOLUTION_TIME } from 'utils/constants'
+import Icon from 'components/Icon'
+
+import css from './Market.scss'
+
+const cx = classNames.bind(css)
+
+
+const MarketStatus = ({ resolved, closed, resolution }) => {
+  const hasStatus = resolved || closed
+  const status = resolved ? 'resolved' : 'closed'
+  const iconType = hasStatus ? 'checkmark' : 'countdown'
+
+  return (
+    <div className={cx('marketInfo')}>
+      <Icon type={iconType} size={25} />
+      <div className={cx('label')}>
+        { hasStatus
+          ? status
+          : <Countdown target={resolution} format={RESOLUTION_TIME.RELATIVE_FORMAT} interval={10000} />
+        }
+      </div>
+    </div>
+  )
+}
+
+MarketStatus.propTypes = {
+  resolved: PropTypes.bool.isRequired,
+  closed: PropTypes.bool.isRequired,
+  resolution: PropTypes.string.isRequired,
+}
+
+export default MarketStatus

--- a/src/embedded/routes/EmbeddedView/components/Market/MarketTrading.js
+++ b/src/embedded/routes/EmbeddedView/components/Market/MarketTrading.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import classNames from 'classnames/bind'
+
+import Icon from 'components/Icon'
+
+import css from './Market.scss'
+
+const cx = classNames.bind(css)
+
+const MarketTrading = ({ volume }) => (
+  <div className={cx('marketInfo')}>
+    <Icon type="currency" size={25} />
+    <div className={cx('label')}>
+      {volume} Volume
+    </div>
+  </div>
+)
+
+MarketTrading.propTypes = {
+  volume: PropTypes.string.isRequired,
+}
+
+export default MarketTrading

--- a/src/embedded/routes/EmbeddedView/components/Market/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Market/index.js
@@ -1,0 +1,130 @@
+import { Record } from 'immutable'
+import PropTypes from 'prop-types'
+import classNames from 'classnames/bind'
+
+import autobind from 'autobind-decorator'
+
+import Decimal from 'decimal.js'
+import moment from 'moment'
+import React from 'react'
+import { RESOLUTION_TIME } from 'utils/constants'
+import MarketResolution from './MarketResolution'
+import MarketStatus from './MarketStatus'
+import MarketTrading from './MarketTrading'
+import Outcome from '../Outcome'
+
+import css from './Market.scss'
+
+const cx = classNames.bind(css)
+
+const decimalToText = (value, decimals = 4) => {
+  if (value && value.toDP) {
+    // toDP is a function of Decimal.js, it rounds the Decimal object to decimals places with rounding mode entered
+    // rounding mode = 1 => round down
+    return value.toDP(decimals, 1).toString()
+  }
+
+  let decimalValue
+  try {
+    decimalValue = Decimal(value)
+  } catch (e) {
+    console.warn(
+      'Invalid prop given to <DecimalValue />: Using 0 as fallback. Please fix this, it causes massive performance issues',
+    )
+    decimalValue = Decimal(0)
+  }
+
+  return decimalValue.toDP(decimals, 1).toString()
+}
+
+class Market extends React.PureComponent {
+  @autobind
+  handleViewMarket() {
+    const { viewMarket, address } = this.props
+
+    viewMarket(address)
+  }
+
+  render() {
+    const { market } = this.props
+    const {
+      resolved,
+      closed,
+      title,
+      resolution,
+      volume,
+      collateralToken,
+    } = this.props
+    const resolutionDate = moment(resolution).format(RESOLUTION_TIME.ABSOLUTE_FORMAT)
+
+    const bounds = market.bounds ? {
+      upperBound: market.bounds.upper,
+      lowerBound: market.bounds.lower,
+      unit: market.bounds.unit,
+      decimals: market.bounds.decimals,
+    } : {}
+
+    const outcomes = market.outcomes ? market.outcomes.map(outcome => outcome.name).toArray() : []
+
+    return (
+      <button
+        onClick={this.handleViewMarket}
+        type="button"
+        className={cx('market', {
+          resolved,
+          closed,
+        })}
+      >
+        <div className={cx('header')}>
+          <h2 className={cx('title')}>{title}</h2>
+        </div>
+        <Outcome
+          resolved={market.resolved}
+          type={market.type}
+          outcomeTokensSold={market.outcomeTokensSold.toArray()}
+          resolution={market.resolution}
+          funding={market.funding}
+          outcomes={outcomes}
+          winningOutcome={market.winningOutcome}
+          {...bounds}
+        />
+        <div className={cx('info', 'row')}>
+          <div className={cx('group', 'col-md-3')}>
+            <MarketStatus
+              resolved={resolved}
+              closed={closed}
+              resolution={resolution}
+            />
+          </div>
+          <div className={cx('group', 'col-md-3')}>
+            <MarketResolution resolution={resolutionDate} />
+          </div>
+          {volume && (
+            <div className={cx('group', 'col-md-3')}>
+              <MarketTrading volume={decimalToText(new Decimal(volume).div(1e18))} collateralToken={collateralToken} />
+            </div>
+          )}
+        </div>
+      </button>
+    )
+  }
+}
+
+Market.propTypes = {
+  market: PropTypes.instanceOf(Record).isRequired,
+  address: PropTypes.string.isRequired,
+  resolved: PropTypes.bool.isRequired,
+  closed: PropTypes.bool.isRequired,
+  isOwner: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  resolution: PropTypes.string.isRequired,
+  volume: PropTypes.string,
+  collateralToken: PropTypes.string.isRequired,
+  viewMarket: PropTypes.func.isRequired,
+}
+
+Market.defaultProps = {
+  volume: undefined,
+}
+
+export default Market

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/TrendingOutcomeCategorical/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/TrendingOutcomeCategorical/index.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames/bind'
+
+import OutcomeColorBox from 'components/Outcome/OutcomeColorBox'
+import style from '../outcomeCategorical.scss'
+
+const cx = cn.bind(style)
+
+const TrendingOutcomeCategorical = ({
+  outcomeIndex, outcome, percentage, resolutionDate,
+}) => (
+  <div className={cx('trendingOutcomeCategoricalContainer')}>
+    <div className={cx('outcomeWrapper')}>
+      <OutcomeColorBox outcomeIndex={outcomeIndex} />
+      <div className={cx('outcome')}>{outcome}</div>
+    </div>
+    &nbsp;
+    <div>{percentage}%</div>
+    <div className={cx('date')}>{resolutionDate}</div>
+  </div>
+)
+
+TrendingOutcomeCategorical.propTypes = {
+  outcomeIndex: PropTypes.number.isRequired,
+  outcome: PropTypes.string,
+  percentage: PropTypes.string,
+  resolutionDate: PropTypes.string,
+}
+
+TrendingOutcomeCategorical.defaultProps = {
+  outcome: '',
+  percentage: '',
+  resolutionDate: '',
+}
+
+export default TrendingOutcomeCategorical

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/index.js
@@ -1,0 +1,101 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames/bind'
+import moment from 'moment'
+import { COLOR_SCHEME_DEFAULT } from 'utils/constants'
+import { calcLMSRMarginalPrice } from '../utils'
+import TrendingOutcomeCategorical from './TrendingOutcomeCategorical'
+
+import style from './outcomeCategorical.scss'
+
+const cx = cn.bind(style)
+
+const OutcomeCategorical = ({
+  resolved,
+  outcomeTokensSold,
+  funding,
+  resolution,
+  outcomes,
+  opts = {},
+}) => {
+  const {
+    showOnlyTrendingOutcome, showDate, dateFormat, className,
+  } = opts
+  const tokenDistribution = outcomes.map((outcome, outcomeIndex) => {
+    const marginalPrice = calcLMSRMarginalPrice({
+      netOutcomeTokensSold: outcomeTokensSold,
+      funding,
+      outcomeTokenIndex: outcomeIndex,
+    })
+
+    return marginalPrice.toFixed(5)
+  })
+
+  // show only trending outcome
+  if (showOnlyTrendingOutcome && !resolved) {
+    const tokenDistributionInt = tokenDistribution.map(outcome => parseInt(parseFloat(outcome) * 10000, 10))
+    const trendingOutcomeIndex = tokenDistributionInt.indexOf(Math.max(...tokenDistributionInt))
+    const trendingMarginalPricePercent = Math.round(tokenDistribution[trendingOutcomeIndex] * 100).toFixed(0)
+    const resolutionDateFormatted = showDate ? moment(resolution).format(dateFormat) : ''
+
+    return (
+      <TrendingOutcomeCategorical
+        outcome={outcomes[trendingOutcomeIndex]}
+        outcomeIndex={trendingOutcomeIndex}
+        percentage={trendingMarginalPricePercent}
+        resolutionDate={resolutionDateFormatted}
+      />
+    )
+  }
+
+  // show all outcomes
+  return (
+    <div className={className}>
+      {outcomes.map((outcome, outcomeIndex) => {
+        const outcomeBarStyle = {
+          width: `${tokenDistribution[outcomeIndex] * 100}%`,
+          backgroundColor: COLOR_SCHEME_DEFAULT[outcomeIndex],
+        }
+        const tokenDistributionPercent = `${Math.round(tokenDistribution[outcomeIndex] * 100).toFixed(0)}%`
+
+        return (
+          <div key={outcome} className={cx('outcome')}>
+            <div className={cx('outcomeBar')}>
+              <div className={cx('outcomeBarInner')} style={outcomeBarStyle}>
+                <div className={cx('outcomeBarLabel')}>
+                  {outcomes[outcomeIndex]}
+                  <div className={cx('outcomeBarValue')}>{tokenDistributionPercent}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+OutcomeCategorical.propTypes = {
+  resolved: PropTypes.bool.isRequired,
+  outcomeTokensSold: PropTypes.array.isRequired,
+  resolution: PropTypes.string.isRequired,
+  funding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  outcomes: PropTypes.array.isRequired,
+  opts: PropTypes.shape({
+    className: PropTypes.string,
+    showOnlyTrendingOutcome: PropTypes.bool,
+    showDate: PropTypes.bool,
+    dateFormat: PropTypes.string,
+  }),
+}
+
+OutcomeCategorical.defaultProps = {
+  opts: {
+    className: '',
+    showOnlyTrendingOutcome: false,
+    showDate: false,
+    dateFormat: '',
+  },
+}
+
+export default OutcomeCategorical

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/outcomeCategorical.scss
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeCategorical/outcomeCategorical.scss
@@ -1,0 +1,69 @@
+@import '~style/vars.scss';
+
+$outcome-bar-height: 15px;
+$outcome-bar-height-leading: 30px;
+
+.outcome {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.outcomeWrapper {
+  max-width: 75%;
+  display: flex;
+  align-items: center;
+}
+
+.outcomeBar {
+  display: inline-block;
+  position: relative;
+  width: 30%;
+  margin: 5px 0;
+}
+
+.outcomeBarInner {
+  height: $outcome-bar-height;
+  position: relative;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  transition: width 1s ease;
+}
+
+.outcomeBarValue {
+  line-height: $outcome-bar-height;
+  vertical-align: middle;
+  padding-left: 5px;
+  display: inline;
+  min-width: 30px;
+  color: $font-color-muted;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.outcomeBarLabel {
+  margin-left: 100%;
+  padding-left: 5px;
+  line-height: $outcome-bar-height;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+.outcomeLabel {
+  display: inline-block;
+}
+
+.date {
+  margin-left: 7px;
+}
+
+.trendingOutcomeCategoricalContainer {
+  display: flex;
+  align-items: center;
+}

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeColorBox/OutcomeColorBox.scss
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeColorBox/OutcomeColorBox.scss
@@ -1,0 +1,10 @@
+.OutcomeColorBox {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-right: 4px;
+
+  background-color: #fff;
+}

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeColorBox/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeColorBox/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import cn from 'classnames/bind'
+import PropTypes from 'prop-types'
+
+import { COLOR_SCHEME_DEFAULT, COLOR_SCHEME_SCALAR, OUTCOME_TYPES } from 'utils/constants'
+
+import styles from './OutcomeColorBox.scss'
+
+const cx = cn.bind(styles)
+
+const COLOR_SCHEMES = {
+  [OUTCOME_TYPES.SCALAR]: COLOR_SCHEME_SCALAR,
+  [OUTCOME_TYPES.CATEGORICAL]: COLOR_SCHEME_DEFAULT,
+}
+
+const OutcomeColorBox = ({ outcomeIndex, scheme }) => (<div className={cx('OutcomeColorBox')} style={{ backgroundColor: COLOR_SCHEMES[scheme][outcomeIndex] }} />)
+
+OutcomeColorBox.propTypes = {
+  outcomeIndex: PropTypes.number.isRequired,
+  scheme: PropTypes.string,
+}
+
+OutcomeColorBox.defaultProps = {
+  scheme: OUTCOME_TYPES.CATEGORICAL,
+}
+
+export default OutcomeColorBox

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/TrendingOutcomeScalar/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/TrendingOutcomeScalar/index.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Decimal from 'decimal.js'
+import DecimalValue from 'components/DecimalValue'
+
+const TrendingOutcomeScalar = ({ predictedValue, unit, decimals }) => (
+  <div className="row">
+    <div className="col-md-6">
+      <DecimalValue value={predictedValue} decimals={decimals} className="outcome__currentPrediction--value" />
+      &nbsp;{unit}
+    </div>
+  </div>
+)
+
+TrendingOutcomeScalar.propTypes = {
+  predictedValue: PropTypes.instanceOf(Decimal),
+  unit: PropTypes.string,
+  decimals: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+}
+
+TrendingOutcomeScalar.defaultProps = {
+  predictedValue: Decimal(0),
+  unit: '',
+  decimals: 0,
+}
+
+export default TrendingOutcomeScalar

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/index.js
@@ -1,0 +1,98 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames/bind'
+import Decimal from 'decimal.js'
+import DecimalValue from 'components/DecimalValue'
+import { calcLMSRMarginalPrice } from '../utils'
+import TrendingOutcomeScalar from './TrendingOutcomeScalar'
+
+import style from './outcomeScalar.scss'
+
+const cx = cn.bind(style)
+
+const OutcomeScalar = ({
+  resolved: showOnlyWinningOutcome,
+  outcomeTokensSold,
+  funding,
+  upperBound,
+  lowerBound,
+  unit,
+  decimals: decimalsRaw,
+  winningOutcome,
+  opts: { showOnlyTrendingOutcome, className = '' },
+}) => {
+  let marginalPrice = calcLMSRMarginalPrice({
+    netOutcomeTokensSold: outcomeTokensSold,
+    funding,
+    outcomeTokenIndex: 1, // always calc for long when calculating estimation
+  })
+
+  const decimals = Math.max(decimalsRaw, 0)
+
+  const lower = Decimal(lowerBound).div(10 ** decimals)
+  const upper = Decimal(upperBound).div(10 ** decimals)
+
+  const bounds = Decimal(upper).sub(lower)
+  let value = Decimal(marginalPrice)
+    .times(bounds)
+    .add(lower)
+
+  const currentValueStyle = { left: `${marginalPrice.mul(100).toFixed(5)}%` }
+
+  if (showOnlyWinningOutcome) {
+    value = Decimal(winningOutcome).div(10 ** decimals)
+    marginalPrice = value.div(upperBound)
+  }
+
+  if (showOnlyTrendingOutcome) {
+    return <TrendingOutcomeScalar predictedValue={value} decimals={decimals} unit={unit} />
+  }
+
+  return (
+    <div className={className}>
+      <div className={cx('scalarOutcome')}>
+        <div className={cx('outcomeBound', 'lower')}>
+          {lower.toNumber().toLocaleString()}
+          &nbsp;
+          {unit}
+        </div>
+        <div className={cx('currentPrediction')}>
+          <div className={cx('currentPredictionLine')} />
+          <div className={cx('currentPredictionValue')} style={currentValueStyle}>
+            <DecimalValue value={value} decimals={decimals} />
+            &nbsp;
+            {unit}
+          </div>
+        </div>
+        <div className={cx('outcomeBound', 'upper')}>
+          {upper.toNumber().toLocaleString()}
+          &nbsp;
+          {unit}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+OutcomeScalar.propTypes = {
+  resolved: PropTypes.bool.isRequired,
+  upperBound: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  lowerBound: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  unit: PropTypes.string.isRequired,
+  decimals: PropTypes.number.isRequired,
+  outcomeTokensSold: PropTypes.array.isRequired,
+  funding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  winningOutcome: PropTypes.number,
+  opts: PropTypes.shape({
+    showOnlyTrendingOutcome: PropTypes.bool,
+  }),
+}
+
+OutcomeScalar.defaultProps = {
+  winningOutcome: undefined,
+  opts: {
+    showOnlyTrendingOutcome: false,
+  },
+}
+
+export default OutcomeScalar

--- a/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/outcomeScalar.scss
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/OutcomeScalar/outcomeScalar.scss
@@ -1,0 +1,68 @@
+@import '~style/vars.scss';
+
+$expandable-arrow-size: 7px;
+
+.scalarOutcome {
+  width: 50%;
+  display: table;
+  margin-top: 40px;
+  white-space: nowrap;
+}
+
+.currentPrediction {
+  position: relative;
+  height: 30px;
+  width: 100%;
+}
+
+
+.currentPredictionLine {
+  position: absolute;
+  background-color: $bg-color-muted;
+  height: 2px;
+  width: 100%;
+  top: 50%;
+  transform: translateY(-1px);
+}
+
+.currentPredictionValue {
+  position: absolute;
+  background-color: $link-color;
+  padding: 5px;
+  border-radius: 5px;
+  color: white;
+  top: 50%;
+  transform: translate(-50%, -38px);
+  transition: left 1s ease;
+  left: 0;
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    margin-left: -$expandable-arrow-size;
+    width: 0;
+    height: 0;
+    border-left: $expandable-arrow-size solid transparent;
+    border-right: $expandable-arrow-size solid transparent;
+    border-top: $expandable-arrow-size solid $link-color;
+  }
+}
+
+.outcomeBound {
+  display: table-cell;
+  width: 15%;
+  height: 30px;
+  vertical-align: middle;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+
+  .lower {
+    text-align: left;
+  }
+  
+  .upper {
+    text-align: right;
+  }
+}

--- a/src/embedded/routes/EmbeddedView/components/Outcome/WinningOutcome/WinningOutcome.scss
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/WinningOutcome/WinningOutcome.scss
@@ -1,0 +1,33 @@
+.winningOutcomeContainer {
+  display: flex;
+  margin: 10px 0 10px 3px;
+  align-items: center;
+  justify-content: flex-start;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.winningOutcomeIcon {
+  background: url('../../../../../../assets/img/icons/icon_winningOutcome.svg');
+  background-size: contain;
+  width: 40px;
+  height: 40px;
+  margin-left: -10px;
+}
+
+.winningOutcomeLabel {
+  color: #87949c;
+  font-size: 12px;
+}
+
+.winningOutcomeText {
+  margin-left: 10px;
+  background-color: #87949c;
+  color: #fff;
+  border-radius: 6px;
+  padding: 5px 10px;
+}
+
+.winningOutcomeUnit {
+  text-transform: none;
+}

--- a/src/embedded/routes/EmbeddedView/components/Outcome/WinningOutcome/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/WinningOutcome/index.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { OUTCOME_TYPES } from 'utils/constants'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+import cn from 'classnames/bind'
+import Decimal from 'decimal.js'
+import style from './WinningOutcome.scss'
+
+const cx = cn.bind(style)
+
+const WinningOutcome = ({
+  type, unit, decimals, winningOutcome,
+}) => {
+  let outcomeText
+
+  if (type === OUTCOME_TYPES.CATEGORICAL) {
+    if (typeof winningOutcome === 'undefined') {
+      outcomeText = (
+        <>
+          <span title={winningOutcome}>Invalid Outcome</span>
+        </>
+      )
+    } else {
+      outcomeText = winningOutcome.name
+    }
+  } else if (type === OUTCOME_TYPES.SCALAR) {
+    const outcomeValue = Decimal(winningOutcome)
+      .div(10 ** decimals)
+      .toString()
+    outcomeText = (
+      <>
+        {outcomeValue} <span className={cx('winningOutcomeUnit')}>{unit}</span>
+      </>
+    )
+  }
+
+  return (
+    <div className={cx('winningOutcomeContainer')}>
+      <div className={cx('winningOutcomeIcon')} />
+      <span className={cx('winningOutcomeLabel')}>
+        Winning
+        <br />
+        outcome
+      </span>
+      <div className={cx('winningOutcomeText')}>{outcomeText}</div>
+    </div>
+  )
+}
+
+WinningOutcome.propTypes = {
+  type: PropTypes.oneOf(Object.keys(OUTCOME_TYPES)).isRequired,
+  winningOutcome: PropTypes.oneOfType([PropTypes.number, ImmutablePropTypes.record]).isRequired,
+  unit: PropTypes.string,
+  decimals: PropTypes.number,
+}
+
+WinningOutcome.defaultProps = {
+  unit: undefined,
+  decimals: 0,
+}
+
+export default WinningOutcome

--- a/src/embedded/routes/EmbeddedView/components/Outcome/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/index.js
@@ -1,0 +1,95 @@
+import React from 'react'
+import ImmutablePropTypes from 'react-immutable-proptypes'
+import PropTypes from 'prop-types'
+import OutcomeCategorical from './OutcomeCategorical'
+import OutcomeScalar from './OutcomeScalar'
+import WinningOutcome from './WinningOutcome'
+
+export const OUTCOME_TYPES = {
+  CATEGORICAL: 'CATEGORICAL',
+  SCALAR: 'SCALAR',
+}
+
+const Outcome = ({
+  resolved,
+  type,
+  upperBound,
+  lowerBound,
+  unit,
+  decimals,
+  outcomeTokensSold,
+  resolution,
+  outcomes,
+  marginalPrices,
+  winningOutcome,
+  funding,
+  opts = { showOnlyTrendingOutcome: false },
+}) => {
+  let outcomeComponent = type === OUTCOME_TYPES.CATEGORICAL ? (
+    <OutcomeCategorical
+      opts={opts}
+      resolved={resolved}
+      outcomeTokensSold={outcomeTokensSold}
+      resolution={resolution}
+      funding={funding}
+      outcomes={outcomes}
+      marginalPrices={marginalPrices}
+      winningOutcome={winningOutcome}
+    />
+  ) : (
+    <OutcomeScalar
+      opts={opts}
+      upperBound={upperBound}
+      lowerBound={lowerBound}
+      unit={unit}
+      decimals={decimals}
+      resolved={resolved}
+      outcomeTokensSold={outcomeTokensSold}
+      resolution={resolution}
+      funding={funding}
+      marginalPrices={marginalPrices}
+      winningOutcome={winningOutcome}
+    />
+  )
+
+  if (resolved) {
+    outcomeComponent = (
+      <WinningOutcome
+        type={type}
+        upperBound={upperBound}
+        lowerBound={lowerBound}
+        unit={unit}
+        decimals={decimals}
+        outcomeTokensSold={outcomeTokensSold}
+        resolution={resolution}
+        outcomes={outcomes}
+        winningOutcome={winningOutcome}
+      />
+    )
+  }
+
+  return outcomeComponent
+}
+
+Outcome.propTypes = {
+  resolved: PropTypes.bool.isRequired,
+  type: PropTypes.oneOf(Object.keys(OUTCOME_TYPES)).isRequired,
+  upperBound: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  lowerBound: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  unit: PropTypes.string,
+  decimals: PropTypes.number,
+  outcomeTokensSold: PropTypes.array.isRequired,
+  resolution: PropTypes.string,
+  funding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  outcomes: PropTypes.array.isRequired,
+  marginalPrices: PropTypes.arrayOf(PropTypes.string),
+  winningOutcome: PropTypes.oneOfType([PropTypes.number, ImmutablePropTypes.record]),
+  opts: PropTypes.shape({
+    showOnlyTrendingOutcome: PropTypes.bool,
+    showDate: PropTypes.bool,
+    dateFormat: PropTypes.string,
+    className: PropTypes.string,
+  }),
+}
+
+export default Outcome

--- a/src/embedded/routes/EmbeddedView/components/Outcome/utils/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/utils/index.js
@@ -1,7 +1,7 @@
 import Decimal from 'decimal.js'
 
 export const calcLMSRMarginalPrice = ({ netOutcomeTokensSold, funding, outcomeTokenIndex }) => {
-  const noTokensSold = netOutcomeTokensSold.filter(quantity => quantity === 0).length === 0
+  const noTokensSold = netOutcomeTokensSold.every(quantity => quantity === 0)
   if (funding === 0 && noTokensSold) {
     return new Decimal(1).div(netOutcomeTokensSold.length)
   }

--- a/src/embedded/routes/EmbeddedView/components/Outcome/utils/index.js
+++ b/src/embedded/routes/EmbeddedView/components/Outcome/utils/index.js
@@ -1,0 +1,27 @@
+import Decimal from 'decimal.js'
+
+export const calcLMSRMarginalPrice = ({ netOutcomeTokensSold, funding, outcomeTokenIndex }) => {
+  const noTokensSold = netOutcomeTokensSold.filter(quantity => quantity === 0).length === 0
+  if (funding === 0 && noTokensSold) {
+    return new Decimal(1).div(netOutcomeTokensSold.length)
+  }
+
+  const b = Decimal(funding).div(Decimal.ln(netOutcomeTokensSold.length))
+  const expOffset = Decimal.max(...netOutcomeTokensSold).div(b)
+
+  return Decimal(netOutcomeTokensSold[outcomeTokenIndex].valueOf())
+    .div(b)
+    .sub(expOffset)
+    .exp()
+    .div(
+      netOutcomeTokensSold.reduce(
+        (acc, tokensSold) => acc.add(
+          Decimal(tokensSold.valueOf())
+            .div(b)
+            .sub(expOffset)
+            .exp(),
+        ),
+        Decimal(0),
+      ),
+    )
+}

--- a/src/embedded/routes/EmbeddedView/components/index.js
+++ b/src/embedded/routes/EmbeddedView/components/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import IndefiniteSpinner from 'components/Spinner/Indefinite'
+import Spinner from 'components/Spinner/Indefinite'
 
-import Market from 'routes/MarketList/components/Markets/Market'
+import Market from './Market'
 import NoMatch from './NoMatch'
 
 
@@ -27,7 +27,7 @@ const EmbeddedView = ({ requestStatus, market }) => {
     return <NoMatch />
   }
 
-  return <IndefiniteSpinner width={50} height={50} />
+  return <Spinner width={50} height={50} />
 }
 
 EmbeddedView.propTypes = {


### PR DESCRIPTION
The bundle size was big because it included pm.js and web3 stuff in it, even if it wasn't used, just imported in some component used. Maybe it could be done with some minifier/webpack settings, but I managed only to achieve it this way.
This PR reduces bundle size from 3.8mb to 673kb and build time from 24s to 8s

### Description
* Move Markets component to embedded route because we need to replace `calcLMSRMarginalPrice` from api there with our util function
* Move `marketBuilders` to the route
* Remove currencyName component in `MarketTrading component` because it imports api functions and thus pm.js and web3 stuff

### Which side effects could my PR have?
* Maybe bugs :))

### Which Steps did I take to verify my PR?

Compared this version on my local server with a deployed version, couldn't notice any difference


